### PR TITLE
Bug Fix: IMU Orientation Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Compatiblity with PCAP captures are incorporated through [pcap libraries](https:
   + The development process of this driver has been performed with mosaic-x5, firmware (FW) revision number 2, and AsteRx-SBi3 Pro, FW revision number 1. If a more up-to-date FW (higher revision number) is uploaded to the mosaic, the driver will not be able to take account of new or updated SBF fields. 
   + ROSaic only works from C++11 onwards due to std::to_string() etc.
   + Septentrio's mosaic receivers and many others are only capable of establishing 10 streams !in total! of SBF blocks / NMEA messages. Please make sure that you do not set too many ROSaic parameters specifying the publishing of ROS messages to `true`. Note that in the GNSS case `gpsfix` accounts for 3 additional streams (`ChannelStatus`, `DOP` and `MeasEpoch` blocks), for instance.
+  + There is a bug on some models that requires setting the IMU Orientation to manual mode even the device is mounted such that the transform is (0,0,0)
   + Once the catkin build or binary installation is finished, adapt the `config/rover.yaml` file according to your needs. The `launch/rover.launch` need not be modified. Specify the communication parameters, the ROS messages to be published, the frequency at which the latter should happen etc.:<br>
 
   ```
@@ -332,9 +333,10 @@ The following is a list of ROSaic parameters found in the `config/rover.yaml` fi
         + default: `0.0`, `0.0` (degrees)
       + `imu_orientation`: IMU sensor orientation
         + `manual_mode`: Choose between using `SensorDefault` or `manual` orientation. If changes are made to `theta_x`, `theta_y`, `theta_z` then mode should be set to `manual`
+        + default: `true`
         + Parameters `theta_x`, `theta_y` and `theta_z` are used to determine the sensor orientation with respect to the vehicle frame. Positive angles correspond to a right-handed (clockwise) rotation of the IMU with respect to its nominal orientation (see below). The order of the rotations is as follows: `theta_z` first, then `theta_y`, then `theta_x`.
         + The nominal orientation is where the IMU is upside up and with the `X axis` marked on the receiver pointing to the front of the vehicle.
-        + default: `true`, `0.0`, `0.0`, `0.0` (degrees)
+        + default: `0.0`, `0.0`, `0.0` (degrees)
       + `poi_to_imu`: The lever arm from the IMU reference point to a user-defined POI
         + Parameters `delta_x`,`delta_y` and `delta_z` refer to the vehicle reference frame
         + default: `0.0`, `0.0`, `0.0` (meters)

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Compatiblity with PCAP captures are incorporated through [pcap libraries](https:
       heading: 0.0
       pitch: 0.0
     imu_orientation:
+      manual_mode: true
       theta_x: 0.0
       theta_y: 0.0
       theta_z: 0.0
@@ -330,9 +331,10 @@ The following is a list of ROSaic parameters found in the `config/rover.yaml` fi
         + `pitch`: Vertical offset can be compensated for by adjusting the `pitch` parameter
         + default: `0.0`, `0.0` (degrees)
       + `imu_orientation`: IMU sensor orientation
+        + `manual_mode`: Choose between using `SensorDefault` or `manual` orientation. If changes are made to `theta_x`, `theta_y`, `theta_z` then mode should be set to `manual`
         + Parameters `theta_x`, `theta_y` and `theta_z` are used to determine the sensor orientation with respect to the vehicle frame. Positive angles correspond to a right-handed (clockwise) rotation of the IMU with respect to its nominal orientation (see below). The order of the rotations is as follows: `theta_z` first, then `theta_y`, then `theta_x`.
         + The nominal orientation is where the IMU is upside up and with the `X axis` marked on the receiver pointing to the front of the vehicle.
-        + default: `0.0`, `0.0`, `0.0` (degrees)
+        + default: `true`, `0.0`, `0.0`, `0.0` (degrees)
       + `poi_to_imu`: The lever arm from the IMU reference point to a user-defined POI
         + Parameters `delta_x`,`delta_y` and `delta_z` refer to the vehicle reference frame
         + default: `0.0`, `0.0`, `0.0` (meters)

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Compatiblity with PCAP captures are incorporated through [pcap libraries](https:
   + The development process of this driver has been performed with mosaic-x5, firmware (FW) revision number 2, and AsteRx-SBi3 Pro, FW revision number 1. If a more up-to-date FW (higher revision number) is uploaded to the mosaic, the driver will not be able to take account of new or updated SBF fields. 
   + ROSaic only works from C++11 onwards due to std::to_string() etc.
   + Septentrio's mosaic receivers and many others are only capable of establishing 10 streams !in total! of SBF blocks / NMEA messages. Please make sure that you do not set too many ROSaic parameters specifying the publishing of ROS messages to `true`. Note that in the GNSS case `gpsfix` accounts for 3 additional streams (`ChannelStatus`, `DOP` and `MeasEpoch` blocks), for instance.
-  + There is a bug on some models that requires setting the IMU Orientation to manual mode even the device is mounted such that the transform is (0,0,0)
+  + There is a bug on some models that requires the IMU Orientation be set to manual mode **even if** the device is mounted such that the transform is (0,0,0)
   + Once the catkin build or binary installation is finished, adapt the `config/rover.yaml` file according to your needs. The `launch/rover.launch` need not be modified. Specify the communication parameters, the ROS messages to be published, the frequency at which the latter should happen etc.:<br>
 
   ```

--- a/config/rover.yaml
+++ b/config/rover.yaml
@@ -87,6 +87,7 @@ ins_spatial_config:
     heading: 0.0
     pitch: 0.0
   imu_orientation:
+    manual_mode: true
     theta_x: 0.0
     theta_y: 0.0
     theta_z: 0.0

--- a/src/septentrio_gnss_driver/node/rosaic_node.cpp
+++ b/src/septentrio_gnss_driver/node/rosaic_node.cpp
@@ -745,6 +745,7 @@ void rosaic_node::ROSaicNode::getROSParams()
 	
 	// INS Spatial Configuration
     // IMU orientation parameter
+    g_nh->param("ins_spatial_config/imu_orientation/manual_mode", manual_, true);
     g_nh->param("ins_spatial_config/imu_orientation/theta_x", theta_x_, 0.0f);
     g_nh->param("ins_spatial_config/imu_orientation/theta_y", theta_y_, 0.0f);
     g_nh->param("ins_spatial_config/imu_orientation/theta_z", theta_z_, 0.0f);


### PR DESCRIPTION
This is a quick PR to fix a bug where ROSaic would always set the IMU orientation mode to `SensorDefault`

**Motivation**
We had a lot of issues getting the SBi3 Pro+ working initially (both with and without using ROSaic). After contacting Septentrio Support, we learned that there is a a bug that requires the IMU orientation to be set to `manual` even if we are mounting the sensor in the default (0,0,0) orientation. That lead us to discover that ROSaic would always the orientation to `SensorDefault`
![2022-01-28_10-55-02_screenshot](https://user-images.githubusercontent.com/88347009/152002338-8dbb9859-b1e9-40ef-9dcb-af9010a54c0a.png)

**Solution**
The solution is fairly simple. `rosaic_node.cpp` already defines a variable `manual_` that represents the IMU orientation mode. The issue was that the variable never got updated from its default value of `false`. This was resolved by adding a parameter the to yaml file and assigning it to the variable `manual_`

**Feedback**
The main point I'd like feedback on is whether I should leave the default value of `manual_mode` to `true`. That is, have ROSaic set the IMU orientation to `manual` by default. It should be fine since the default values for each orientation angle are 0. Also, having it in `true` by default could prevent future users from falling into the same confusion about needing to always set the IMU orientation to `manual` (assuming that bug in the sensor persists)